### PR TITLE
Revision v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The human `GRCh37` genome is set as default.
 | WBcel235      |       *Caenorhabditis elegans*   |       Nematode     |
 
 
+**NOTE! With the option --genome 'ALL', the entire dataset of mature miRNAs and hairpins in miRBase will be used as reference regardless of species. Meanwhile the alignment against host reference genome will be skipped.**
+
 ### `-c`
 Specify the path to a specific config file (this is a core NextFlow command). Useful if using different UPPMAX
 projects or different sets of reference genomes.

--- a/main.nf
+++ b/main.nf
@@ -321,7 +321,7 @@ process miRBasePostAlignment {
 
     script:
     """
-    f='$input';f=(\$f);f=\${f[0]};f=\${f%.bam}
+    f='$input'; f=\${f%.bam}
 
     samtools sort \${f}.bam \${f}.sorted
     samtools index \${f}.sorted.bam
@@ -502,7 +502,7 @@ process bowtie2 {
       -U $reads \\
       -k 10 \\
       --very-sensitive \\
-      -p 1 \\
+      -p 8 \\
       -t \\
       | samtools view -bT $index - > \${f}.bowtie2.bam
     """

--- a/main.nf
+++ b/main.nf
@@ -467,6 +467,15 @@ process edgeR_miRBase_mature {
       dev.off()
     }
 
+    # Print distance matrix to file
+    write.table(MDSdata\$distance.matrix, paste(header,"_edgeR_MDS_distance_matrix.txt",sep=""), quote=FALSE, sep="\\t")
+
+    # Print plot x,y co-ordinates to file
+    MDSxy = MDSdata\$cmdscale.out
+    colnames(MDSxy) = c(paste(MDSdata\$axislabel, '1'), paste(MDSdata\$axislabel, '2'))
+
+    write.table(MDSxy, paste(header,"_edgeR_MDS_plot_coordinates.txt",sep=""), quote=FALSE, sep="\\t")
+
     # Get the log counts per million values
     logcpm <- cpm(dataNorm, prior.count=2, log=TRUE)
 
@@ -482,6 +491,9 @@ process edgeR_miRBase_mature {
     pdf(paste(header,"_log2CPM_sample_distances_dendrogram.pdf",sep=""))
     plot(hmap\$rowDendrogram, main="Sample Dendrogram")
     dev.off()
+
+    # Write clustered distance values to file
+    write.table(hmap\$carpet, paste(header,"_log2CPM_sample_distances.txt",sep=""), quote=FALSE, sep="\\t")
     }
 
     file.create("corr.done")


### PR DESCRIPTION
1) Add support to use the miRBase sequences of ALL species as reference;
2) Wrap result files for 'mature' and 'hairpin' in different publish directories;
3) Small changes to add and remove some result files.
